### PR TITLE
Card article: adjust padding and title font-size

### DIFF
--- a/src/components/_card.scss
+++ b/src/components/_card.scss
@@ -32,11 +32,11 @@
   }
 
   &-content {
-    padding: $p-v-large $p-h;
+    padding: $p-v $p-h $p-v-large;
   }
 
   &-title {
-    @include h2;
+    @include h3;
   }
 
   &-description {


### PR DESCRIPTION
Adjusting `padding` and title `font-size`, in order to fit with `news detail` design