### PR TITLE
form elements refactor

### DIFF
--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -157,6 +157,8 @@ $bxsh-base: 0 1px $bxsh-spread rgba($c-black, .15) !default;
 $bgc-input: $c-white !default;
 $bgc-input-hover: $c-white !default;
 $bgc-input-focus: $c-gray-lightest !default;
+$c-input-placeholder: $c-text-base !default;
+$fs-input-placeholder: italic !default;
 $lh-input: $lh-base !default;
 
 $bd-input: 0 0 0 1px  $c-gray inset !default;

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -157,6 +157,7 @@ $bxsh-base: 0 1px $bxsh-spread rgba($c-black, .15) !default;
 $bgc-input: $c-white !default;
 $bgc-input-hover: $c-white !default;
 $bgc-input-focus: $c-gray-lightest !default;
+$lh-input: $lh-base !default;
 
 $bd-input: 0 0 0 1px  $c-gray inset !default;
 $bd-input-hover: 0 0 0 1px  $c-gray inset !default;
@@ -176,6 +177,7 @@ $p-radio-list: $p-v $p-h !default;
 $bgc-select: $c-white !default;
 $bgc-select-hover: $c-white !default;
 $bgc-select-focus: $c-gray-lightest !default;
+$lh-select: $lh-base !default;
 
 $bgc-select-icon-wrap: $c-gray-lightest !default;
 $p-select-icon-wrap: 0 $p-h-small !default;

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -158,9 +158,9 @@ $bgc-input: $c-white !default;
 $bgc-input-hover: $c-white !default;
 $bgc-input-focus: $c-gray-lightest !default;
 
-$bd-input: 1px solid $c-gray !default;
-$bd-input-hover: 1px solid $c-gray !default;
-$bd-input-focus: 1px solid $c-gray !default;
+$bd-input: 0 0 0 1px  $c-gray inset !default;
+$bd-input-hover: 0 0 0 1px  $c-gray inset !default;
+$bd-input-focus: 0 0 0 1px  $c-gray inset !default;
 
 // Radio List
 $bd-radio-list: 1px solid $c-gray !default;
@@ -181,9 +181,9 @@ $bgc-select-icon-wrap: $c-gray-lightest !default;
 $p-select-icon-wrap: 0 $p-h-small !default;
 $w-select-icon-wrap: 30px !default;
 
-$bd-select: 1px solid $c-gray !default;
-$bd-select-hover: 1px solid $c-gray !default;
-$bd-select-focus: 1px solid $c-gray !default;
+$bd-select: 0 0 0 1px $c-gray inset !default;
+$bd-select-hover: 0 0 0 1px $c-gray inset !default;
+$bd-select-focus: 0 0 0 1px $c-gray inset !default;
 
 
 // --- Components --- //
@@ -217,6 +217,7 @@ $bgc-alert-basic-success: $c-white !default;
 
 // Button
 $bdrs-button: 0 !default;
+$lh-button: $lh-base !default;
 $o-button-disabled: .4 !default;
 
 $c-button-primary: $c-white !default;

--- a/src/components/_button.scss
+++ b/src/components/_button.scss
@@ -19,6 +19,7 @@
   cursor: pointer;
   display: flex;
   font-family: $ff-sans-serif;
+  line-height: $lh-button;
   outline: none;
   padding: $p-v $p-h;
 

--- a/src/components/_input.scss
+++ b/src/components/_input.scss
@@ -6,7 +6,8 @@
 
 @mixin sui-input($size: 'medium') {
   @include input-placeholder {
-    font-style: italic;
+    color: $c-input-placeholder;
+    font-style: $fs-input-placeholder;
   }
 
   background-color: $bgc-input;

--- a/src/components/_input.scss
+++ b/src/components/_input.scss
@@ -2,33 +2,42 @@
 
 // --- SUI Input --- //
 // @include sui-input;
+// @include sui-input('large');
 
-@mixin sui-input {
+@mixin sui-input($size: 'medium') {
   @include input-placeholder {
     font-style: italic;
   }
 
   background-color: $bgc-input;
-  border: $bd-input;
+  border: 0;
   border-radius: $bdrs-base;
+  box-shadow: $bd-input;
   font-family: $ff-sans-serif;
-  font-size: $fz-l;
   font-weight: $fw-light;
+  line-height: $lh-base;
   outline: none;
   padding: $p-v $p-h;
   width: 100%;
 
+  @if $size == 'medium' {
+    font-size: $fz-base;
+  }
+  @if $size == 'large' {
+    font-size: $fz-l;
+  }
+
   &:hover {
     background-color: $bgc-input-hover;
-    border: $bd-input-hover;
+    box-shadow: $bd-input-hover;
   }
 
   &:focus {
     background-color: $bgc-input-focus;
-    border: $bd-input-focus;
+    box-shadow: $bd-input-focus;
   }
 
   &.has-error {
-    border: 1px solid $c-error;
+    box-shadow: 1px solid $c-error;
   }
 }

--- a/src/components/_input.scss
+++ b/src/components/_input.scss
@@ -15,7 +15,7 @@
   box-shadow: $bd-input;
   font-family: $ff-sans-serif;
   font-weight: $fw-light;
-  line-height: $lh-base;
+  line-height: $lh-input;
   outline: none;
   padding: $p-v $p-h;
   width: 100%;

--- a/src/components/_select.scss
+++ b/src/components/_select.scss
@@ -9,18 +9,27 @@
 // </div>
 //
 // @include sui-select;
+// @include sui-select('large');
 
-@mixin sui-select {
+@mixin sui-select($size: 'medium') {
   @include appearance(none);
   background-color: $bgc-select;
-  border: $bd-select;
+  border: 0;
   border-radius: $bdrs-base;
+  box-shadow: $bd-select;
   display: inline-block;
   font-family: $ff-sans-serif;
-  font-size: $fz-l;
+  line-height: $lh-base;
   outline: none;
   padding: $p-v $p-h;
   width: 100%;
+
+  @if $size == 'medium' {
+    font-size: $fz-base;
+  }
+  @if $size == 'large' {
+    font-size: $fz-l;
+  }
 
   &-wrap {
     position: relative;
@@ -41,11 +50,11 @@
 
   &:hover {
     background-color: $bgc-select-hover;
-    border: $bd-select-hover;
+    box-shadow: $bd-select-hover;
   }
 
   &:focus {
     background-color: $bgc-select-focus;
-    border: $bd-select-focus;
+    box-shadow: $bd-select-focus;
   }
 }

--- a/src/components/_select.scss
+++ b/src/components/_select.scss
@@ -19,7 +19,7 @@
   box-shadow: $bd-select;
   display: inline-block;
   font-family: $ff-sans-serif;
-  line-height: $lh-base;
+  line-height: $lh-select;
   outline: none;
   padding: $p-v $p-h;
   width: 100%;


### PR DESCRIPTION
## This PR contains breaking changes, so i will upgrade a **major** release:

- Add customizable `line-height` to button, so large buttons increases its height.
- Set `inputs` and `selects` sizes, by passing the parameter `medium` or `large`  to the mixin (default is `medium`).
- switch `border` to `box-shadow` in `selects` and `inputs`, so they can be aligned with buttons.

**CAUTION:**
if you are overwriting some of this variables in your theme:

`$bd-input`
`$bd-input-hover`
`$bd-input-hover`
`$bd-select`
`$bd-select-hover`
`$bd-select-focus`

you may want to change your border declarations to box shadow. 
ie: `$bd-select: 1px solid $your-color` -> `$bd-select: 0 0 0 1px $your-color inset`