### PR TITLE
feat(components): add new variables for component section basic.

### DIFF
--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -386,9 +386,12 @@ $bg-search-box: $c-gray-light !default;
 $c-section-basic-main-title: $c-black !default;
 $c-section-basic-subtitle: $c-gray-light !default;
 $c-section-basic-content-text-paragraph: $c-gray !default;
+$fz-section-basic-subtitle: $fz-h5 !default;
+$fz-section-basic-content-text-paragraph: $fz-m !default;
+$lh-section-basic-paragraph: $lh-base !default;
 $mb-section-basic: $m-v-xlarge * 2 !default;
 $mb-section-basic-header: $m-v-xlarge !default;
-$m-v-section-basic-content-text-paragraph: $m-v-xlarge !default;
+$m-v-section-basic-content-text-paragraph: $m-v-large !default;
 
 // Smartbanner
 $bgc-ad-smartbanner: $c-white !default;

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -382,6 +382,14 @@ $p-modal-basic-footer: $p-base !default;
 // Search box
 $bg-search-box: $c-gray-light !default;
 
+// Section
+$c-section-basic-main-title: $c-black !default;
+$c-section-basic-subtitle: $c-gray-light !default;
+$c-section-basic-content-text-paragraph: $c-gray !default;
+$mb-section-basic: $m-v-xlarge * 2 !default;
+$mb-section-basic-header: $m-v-xlarge !default;
+$m-v-section-basic-content-text-paragraph: $m-v-xlarge !default;
+
 // Smartbanner
 $bgc-ad-smartbanner: $c-white !default;
 $bb-ad-smartbanner: 1px solid $c-gray-light !default;

--- a/src/utils/_breakpoints.scss
+++ b/src/utils/_breakpoints.scss
@@ -61,8 +61,8 @@
 // Media that spans multiple breakpoint widths.
 // Makes the @content apply between the min and max breakpoints
 @mixin media-breakpoint-between($lower, $upper) {
-  @include media-breakpoint-up($lower, $breakpoints) {
-    @include media-breakpoint-down($upper, $breakpoints) {
+  @include media-breakpoint-up($lower) {
+    @include media-breakpoint-down($upper) {
       @content;
     }
   }
@@ -72,7 +72,7 @@
 // No minimum for the smallest breakpoint, and no maximum for the largest one.
 // Makes the @content apply only to the given breakpoint, not viewports any wider or narrower.
 @mixin media-breakpoint-only($name) {
-  @include media-breakpoint-between($name, $name, $breakpoints) {
+  @include media-breakpoint-between($name, $name) {
     @content;
   }
 }


### PR DESCRIPTION
Moved sui-section-basic variables to theme-basic.

Additionally, an error in breakpoints mixins has been solved, removing a unnecesary variable which was generating the following error when using "media-breakpoint-between" and "media-breakpoint-only" mixins:

**Module build failed: 
  @include media-breakpoint-between($name, $name, $breakpoints) {
          ^
      Wrong number of arguments (3 for 2) for `media-breakpoint-between'
      in node_modules/@schibstedspain/theme-basic/lib/utils/_breakpoints.scss (line 75, column 12)
Error: 
  @include media-breakpoint-between($name, $name, $breakpoints) {
          ^
      Wrong number of arguments (3 for 2) for `media-breakpoint-between'**