### PR TITLE
refactor(settings): refactor colors to be compliant to new design

### DIFF
--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -21,6 +21,7 @@
 $url-statics: '' !default;
 
 @import './settings/color';
+@import './settings-compat-v7/color';
 @import './settings/font';
 @import './settings/spacing';
 @import './settings/layout';

--- a/src/settings-compat-v7/_color.scss
+++ b/src/settings-compat-v7/_color.scss
@@ -1,0 +1,11 @@
+// --- Colors --- //
+// This is a layer to maintain compatiblity with version 7-
+
+// Colors non-existing in the new color palette
+$c-highlighted: #f2cd96 !default; // seem not used
+$c-featured: #ffe613 !default; // used as category tag
+$c-white: #ffffff !default; // not semantic
+$c-black: $c-system !default; // not semantic
+
+// Colors renamed in the new color palette
+$c-warning: $c-alert !default; // This color corresponds to $c-alert

--- a/src/settings/_color.scss
+++ b/src/settings/_color.scss
@@ -1,9 +1,3 @@
-// --- Colors --- //
-
-// Shade step {color}-light or {color}-dark variation
-$c-dark-step: -2 !default;
-$c-light-step: 2 !default;
-
 ///////////////////////////////////////////////////////////////////////////////
 // Color Palette
 ///////////////////////////////////////////////////////////////////////////////
@@ -13,35 +7,35 @@ $c-system: #000 !default;
 
 // Primary color
 $c-primary: #005496 !default;
-$c-primary-light: color-variation($c-primary, $c-light-step) !default;
-$c-primary-dark: color-variation($c-primary, $c-dark-step) !default;
+$c-primary-light: light-variation($c-primary) !default;
+$c-primary-dark: dark-variation($c-primary) !default;
 
 // Secondary/Accent color
 $c-accent: #964200 !default;
-$c-accent-light: color-variation($c-accent, $c-light-step) !default;
-$c-accent-dark: color-variation($c-accent, $c-dark-step) !default;
+$c-accent-light: light-variation($c-accent) !default;
+$c-accent-dark: dark-variation($c-accent) !default;
 
 // Gray color
 $c-gray: #777777 !default;
-$c-gray-light: color-variation($c-gray, $c-light-step) !default;
-$c-gray-dark: color-variation($c-gray, $c-dark-step) !default;
+$c-gray-light: light-variation($c-gray) !default;
+$c-gray-dark: dark-variation($c-gray) !default;
 $c-gray-lightest: color-variation($c-gray, 4) !default;
 
 
 // Success color
 $c-success: #8bc34a !default;
-$c-success-light: color-variation($c-success, $c-light-step) !default;
-$c-success-dark: color-variation($c-success, $c-dark-step) !default;
+$c-success-light: light-variation($c-success) !default;
+$c-success-dark: dark-variation($c-success) !default;
 
 // Alert color
 $c-alert: #f5a623 !default;
-$c-alert-light: color-variation($c-alert, $c-light-step) !default;
-$c-alert-dark: color-variation($c-alert, $c-dark-step) !default;
+$c-alert-light: light-variation($c-alert) !default;
+$c-alert-dark: dark-variation($c-alert) !default;
 
 // Error/Warning color
 $c-error: #f44c23 !default;
-$c-error-light: color-variation($c-error, $c-light-step) !default;
-$c-error-dark: color-variation($c-error, $c-dark-step) !default;
+$c-error-light: light-variation($c-error) !default;
+$c-error-dark: dark-variation($c-error) !default;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Specific Colors

--- a/src/settings/_color.scss
+++ b/src/settings/_color.scss
@@ -1,36 +1,58 @@
 // --- Colors --- //
 
-// Main
-$c-primary-light: #80a9ca !default;
+// Shade step {color}-light or {color}-dark variation
+$c-dark-step: -2 !default;
+$c-light-step: 2 !default;
+
+///////////////////////////////////////////////////////////////////////////////
+// Color Palette
+///////////////////////////////////////////////////////////////////////////////
+
+// System color
+$c-system: #000 !default;
+
+// Primary color
 $c-primary: #005496 !default;
-$c-primary-dark: #003661 !default;
-$c-highlighted: #f2cd96 !default;
+$c-primary-light: color-variation($c-primary, $c-light-step) !default;
+$c-primary-dark: color-variation($c-primary, $c-dark-step) !default;
 
+// Secondary/Accent color
 $c-accent: #964200 !default;
-$c-accent-light: #caa080 !default;
-$c-accent-dark: #612a00 !default;
+$c-accent-light: color-variation($c-accent, $c-light-step) !default;
+$c-accent-dark: color-variation($c-accent, $c-dark-step) !default;
 
-$c-featured: #ffe613 !default;
-
-$c-white: #ffffff !default;
-$c-black: #000000 !default;
-
-$c-error: #d92b2b !default;
-$c-warning: #e69c2e !default;
-$c-success: #8cbf26 !default;
-
-// Grays
+// Gray color
 $c-gray: #777777 !default;
-$c-gray-dark: #4d4d4d !default;
-$c-gray-light: #bbbbbb !default;
-$c-gray-lightest: #f1f1f1 !default;
+$c-gray-light: color-variation($c-gray, $c-light-step) !default;
+$c-gray-dark: color-variation($c-gray, $c-dark-step) !default;
+$c-gray-lightest: color-variation($c-gray, 4) !default;
 
-// Text
+
+// Success color
+$c-success: #8bc34a !default;
+$c-success-light: color-variation($c-success, $c-light-step) !default;
+$c-success-dark: color-variation($c-success, $c-dark-step) !default;
+
+// Alert color
+$c-alert: #f5a623 !default;
+$c-alert-light: color-variation($c-alert, $c-light-step) !default;
+$c-alert-dark: color-variation($c-alert, $c-dark-step) !default;
+
+// Error/Warning color
+$c-error: #f44c23 !default;
+$c-error-light: color-variation($c-error, $c-light-step) !default;
+$c-error-dark: color-variation($c-error, $c-dark-step) !default;
+
+///////////////////////////////////////////////////////////////////////////////
+// Specific Colors
+///////////////////////////////////////////////////////////////////////////////
+
+// Text colors
 $c-text-base: $c-gray-dark !default;
 $c-text-accent: $c-accent !default;
 $c-text-link: $c-text-accent !default;
 
-// Social
+// Social brand colors
 $c-facebook: #3b5998 !default;
 $c-twitter: #55acee !default;
 $c-google: #d34836 !default;

--- a/src/settings/_color.scss
+++ b/src/settings/_color.scss
@@ -1,3 +1,9 @@
+// --- Colors --- //
+
+// Shade step {color}-light or {color}-dark variation
+$c-dark-step: -2 !default;
+$c-light-step: 2 !default;
+
 ///////////////////////////////////////////////////////////////////////////////
 // Color Palette
 ///////////////////////////////////////////////////////////////////////////////
@@ -7,35 +13,35 @@ $c-system: #000 !default;
 
 // Primary color
 $c-primary: #005496 !default;
-$c-primary-light: light-variation($c-primary) !default;
-$c-primary-dark: dark-variation($c-primary) !default;
+$c-primary-light: color-variation($c-primary, $c-light-step) !default;
+$c-primary-dark: color-variation($c-primary, $c-dark-step) !default;
 
 // Secondary/Accent color
 $c-accent: #964200 !default;
-$c-accent-light: light-variation($c-accent) !default;
-$c-accent-dark: dark-variation($c-accent) !default;
+$c-accent-light: color-variation($c-accent, $c-light-step) !default;
+$c-accent-dark: color-variation($c-accent, $c-dark-step) !default;
 
 // Gray color
 $c-gray: #777777 !default;
-$c-gray-light: light-variation($c-gray) !default;
-$c-gray-dark: dark-variation($c-gray) !default;
+$c-gray-light: color-variation($c-gray, $c-light-step) !default;
+$c-gray-dark: color-variation($c-gray, $c-dark-step) !default;
 $c-gray-lightest: color-variation($c-gray, 4) !default;
 
 
 // Success color
 $c-success: #8bc34a !default;
-$c-success-light: light-variation($c-success) !default;
-$c-success-dark: dark-variation($c-success) !default;
+$c-success-light: color-variation($c-success, $c-light-step) !default;
+$c-success-dark: color-variation($c-success, $c-dark-step) !default;
 
 // Alert color
 $c-alert: #f5a623 !default;
-$c-alert-light: light-variation($c-alert) !default;
-$c-alert-dark: dark-variation($c-alert) !default;
+$c-alert-light: color-variation($c-alert, $c-light-step) !default;
+$c-alert-dark: color-variation($c-alert, $c-dark-step) !default;
 
 // Error/Warning color
 $c-error: #f44c23 !default;
-$c-error-light: light-variation($c-error) !default;
-$c-error-dark: dark-variation($c-error) !default;
+$c-error-light: color-variation($c-error, $c-light-step) !default;
+$c-error-dark: color-variation($c-error, $c-dark-step) !default;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Specific Colors

--- a/src/utils/_colors.scss
+++ b/src/utils/_colors.scss
@@ -1,9 +1,5 @@
 // --- Color --- //
 
-// Variation step {color}-light or {color}-dark variation
-$c-dark-variation-step: -2 !default;
-$c-light-variation-step: 2 !default;
-
 // Color Variations Function:
 
 // Description:
@@ -37,16 +33,4 @@ $c-light-variation-step: 2 !default;
   } @else {
     @return mix(white, $color, nth($step-variations-positive, $step));
   }
-}
-
-// Dark Variations Function
-// Returns the darker variation of a color, as defined in color palette
-@function dark-variation($color) {
-  @return color-variation($color, $c-dark-variation-step)
-}
-
-// Light Variations Function
-// Returns the lighter variation of a color, as defined in color palette
-@function light-variation($color) {
-  @return color-variation($color, $c-light-variation-step)
 }

--- a/src/utils/_colors.scss
+++ b/src/utils/_colors.scss
@@ -1,5 +1,9 @@
 // --- Color --- //
 
+// Variation step {color}-light or {color}-dark variation
+$c-dark-variation-step: -2 !default;
+$c-light-variation-step: 2 !default;
+
 // Color Variations Function:
 
 // Description:
@@ -33,4 +37,16 @@
   } @else {
     @return mix(white, $color, nth($step-variations-positive, $step));
   }
+}
+
+// Dark Variations Function
+// Returns the darker variation of a color, as defined in color palette
+@function dark-variation($color) {
+  @return color-variation($color, $c-dark-variation-step)
+}
+
+// Light Variations Function
+// Returns the lighter variation of a color, as defined in color palette
+@function light-variation($color) {
+  @return color-variation($color, $c-light-variation-step)
 }


### PR DESCRIPTION
For now, the compatibility layer is added to the main settings during the refactor to check everything works fine as a whole.

When refactor ends we'll remove compa imports and bump to major version (@s-ui-theme)

Color where changed. They may vary but it should not affect projects.